### PR TITLE
Try to fix normal runtime error in the training phase

### DIFF
--- a/source/unitree_rl_lab/unitree_rl_lab/tasks/locomotion/agents/rsl_rl_ppo_cfg.py
+++ b/source/unitree_rl_lab/unitree_rl_lab/tasks/locomotion/agents/rsl_rl_ppo_cfg.py
@@ -14,8 +14,11 @@ class BasePPORunnerCfg(RslRlOnPolicyRunnerCfg):
     save_interval = 100
     experiment_name = ""  # same as task name
     empirical_normalization = False
+    # Clip actions passed to the environment to prevent action-rate/reward explosions
+    clip_actions = 1.0
     policy = RslRlPpoActorCriticCfg(
         init_noise_std=1.0,
+        noise_std_type="log",
         actor_hidden_dims=[512, 256, 128],
         critic_hidden_dims=[512, 256, 128],
         activation="elu",


### PR DESCRIPTION
Hi,

As discussed in https://github.com/unitreerobotics/unitree_rl_lab/issues/24

It seems G1 velocity demo is not working properly, please have a check.

As [zhenwang-civil](https://github.com/zhenwang-civil) suggested, change `bad_orientation = DoneTerm(func=mdp.bad_orientation, params={"limit_angle": 0.8})` from 0.8 to 0.7 does fix this problem.

But I not so sure if this the best solution, after dig into the doc and help from codex/claude, it seems we can also change the loss function def.

But still, I am new to this area, please give some commits @Agnel-Wang 

Sincerely,
MiaoDX