### PR TITLE
fix(deploy/g1): garbage mimic anchor observation (Eigen use-after-scope) and unsafe Mimic FSM entry

### DIFF
--- a/deploy/robots/g1_29dof/include/State_Mimic.h
+++ b/deploy/robots/g1_29dof/include/State_Mimic.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <atomic>
+
 #include "FSM/State_RLBase.h"
 
 class State_Mimic : public FSMState
@@ -28,6 +30,7 @@ private:
 
     std::thread policy_thread;
     bool policy_thread_running = false;
+    std::atomic<bool> first_action_{false}; // run() must not push actions before the first env->step()
     std::array<float, 2> time_range_;
 };
 

--- a/deploy/robots/g1_29dof/src/State_Mimic.cpp
+++ b/deploy/robots/g1_29dof/src/State_Mimic.cpp
@@ -95,8 +95,12 @@ REGISTER_OBSERVATION(motion_anchor_ori_b)
     auto real_quat_w = torso_quat_w(env);
     auto ref_quat_w = anchor_quat_w(State_Mimic::motion);
 
-    auto rot_ = (init_quat * ref_quat_w).conjugate() * real_quat_w;
-    auto rot = rot_.toRotationMatrix().transpose();
+    Eigen::Quaternionf rot_ = (init_quat * ref_quat_w).conjugate() * real_quat_w;
+    // Materialize the matrix: with `auto`, transpose() is a lazy expression that
+    // references the temporary returned by toRotationMatrix(), which is destroyed
+    // at the end of this statement. Reading rot(i,j) afterwards is use-after-scope
+    // and fills the observation with garbage.
+    Eigen::Matrix3f rot = rot_.toRotationMatrix().transpose();
 
     Eigen::Matrix<float, 6, 1> data;
     data << rot(0, 0), rot(0, 1), rot(1, 0), rot(1, 1), rot(2, 0), rot(2, 1);
@@ -170,7 +174,18 @@ void State_Mimic::enter()
     }
 
     motion = motion_; // set for specific motion
+    // Refresh robot data before any anchor math (State_RLBase::enter() does this
+    // too). On the first entry data.root_quat_w has never been filled, so
+    // init_quat and motion->reset() would otherwise use uninitialized data.
+    env->robot->update();
     env->reset();
+    // Hold the measured pose until the policy computes its first action;
+    // otherwise run() pushes zero/stale targets for the first control ticks.
+    for (int i = 0; i < env->robot->data.joint_ids_map.size(); ++i) {
+        int idx = env->robot->data.joint_ids_map[i];
+        lowcmd->msg_.motor_cmd()[idx].q() = lowstate->msg_.motor_state()[idx].q();
+    }
+    first_action_ = false;
     // Start policy thread
     policy_thread_running = true;
     policy_thread = std::thread([this]{
@@ -193,6 +208,7 @@ void State_Mimic::enter()
             env->robot->update();
             motion->update(env->episode_length * env->step_dt + time_range_[0]);
             env->step();
+            first_action_ = true;
 
             // Sleep
             std::this_thread::sleep_until(sleepTill);
@@ -204,6 +220,7 @@ void State_Mimic::enter()
 
 void State_Mimic::run()
 {
+    if (!first_action_) return; // keep holding the entry pose set in enter()
     auto action = env->action_manager->processed_actions();
     for(int i(0); i < env->robot->data.joint_ids_map.size(); i++) {
         lowcmd->msg_.motor_cmd()[env->robot->data.joint_ids_map[i]].q() = action[i];


### PR DESCRIPTION
## Summary

Two bugs in the g1_29dof deploy controller make **every `Mimic` FSM state — including the stock `dance_102` — receive corrupted inputs and command violent actions at entry**. In MuJoCo sim2sim the robot is thrown over within ~150 ms of starting any mimic motion (knee torque saturates instantly, arms sweep >3 rad in ~120 ms). Both are fixed here; the diff is 22 lines in `State_Mimic.{cpp,h}`.

## Bug 1 — use-after-scope in `motion_anchor_ori_b` (Eigen lazy expression)

```cpp
auto rot_ = (init_quat * ref_quat_w).conjugate() * real_quat_w;
auto rot = rot_.toRotationMatrix().transpose();   // <-- UB
```

`toRotationMatrix()` returns a temporary `Matrix3f`; `.transpose()` returns a lazy `Eigen::Transpose` expression that **references** that temporary. With `auto`, the expression (not a matrix) is stored, the temporary is destroyed at the end of the statement, and every subsequent `rot(i, j)` reads freed stack memory. This is the classic Eigen `auto` pitfall ([Eigen docs: "C++11 and the auto keyword"](https://eigen.tuxfamily.org/dox/TopicPitfalls.html)).

Observed effect: instrumenting the observation vector at mimic entry showed the 6 anchor-orientation elements intermittently containing values like `3.29e15` (a rotation-matrix element cannot exceed 1), varying run-to-run as stack reuse changed. The policy then outputs divergent actions on every step.

**Fix:** materialize the result — `Eigen::Matrix3f rot = rot_.toRotationMatrix().transpose();`

## Bug 2 — entry race: actions pushed before the first inference, anchor math on stale data

- `State_Mimic::run()` copies `action_manager->processed_actions()` into `lowcmd` from the 1 kHz FSM loop immediately after `enter()`, but the policy thread has not yet completed its first `env->step()`. The robot receives all-zero targets on first entry (`_processed_actions` is zero-initialized) or stale targets from the previous run of that state (`JointAction::reset()` only clears `_raw_actions`).
- Inside the policy thread, `init_quat` and `motion->reset(env->robot->data, ...)` are computed **before** the first `env->robot->update()`. On the first entry of a `State_Mimic` instance, `data.root_quat_w` has never been written (each state owns its own articulation), so the yaw alignment is computed from uninitialized data. Note `State_RLBase::enter()` already calls `env->robot->update()` before starting its thread — `State_Mimic` was missing the same call.

**Fix:** refresh robot data in `enter()` before the anchor math; write the currently measured joint positions into `lowcmd` at entry; gate `run()` on an atomic `first_action_` flag set after the first `env->step()`. Until then the robot simply holds its measured pose under the new gains.

## Verification

MuJoCo sim2sim (`unitree_mujoco`, `scene_29dof.xml`, `g1_ctrl --network lo`), G1 29-DoF:

| | before | after |
|---|---|---|
| `dance_102` entry from Velocity | thrown over in ~174 ms | — |
| custom mimic policy entry | knee τ saturates at +139 Nm within 13 ms, shoulder sweeps 0.22→3.08 rad in 120 ms, falls | plays to `time_end`, auto-returns to Velocity, robot standing |
| `RB+X` mid-motion | — | returns to Velocity, robot stays standing |
| anchor obs at entry | elements up to ~1e15 | proper rotation-matrix elements |

The first-torque-spike signature (garbage targets applied within a few ms of entry, i.e. before the first 20 ms policy step could even finish) was what isolated Bug 2 from Bug 1.

Since these bugs corrupt the observation/action stream at the moment gains soften and the pose target jumps, they are dangerous on real hardware, not just in simulation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
